### PR TITLE
Add download policy to allow download skips

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ For Amazon EC2 users with IAM roles configured: you dont have to set `key`, `sec
 and `region`. Dep cache will automatically pick up configuration from the EC2 environment.
 The only required option is `bucket`.
 
+### Download Policy
+
+For each `cache` entry in the config you can specify a `download_policy` parameter.
+
+Available options are:
+- `default` - Default policy. Always download and extract data into the cache directory.
+- `skip_not_empty` - Skip download if the cache directory already exists and is not empty.
+
+Example:
+
+```json
+{
+  "cache": [
+    {
+      "manifest": "Gemfile.lock",
+      "path": ".bundle",
+      "prefix": "bundler",
+      "download_policy": "skip_not_empty"
+    }
+  ]
+}
+```
+
 ## Usage
 
 Take a look at the example project structure (real files omitted):
@@ -66,7 +89,7 @@ Next, perform download, install and upload of dependencies:
 
 ```bash
 # This will download the archives if they exist in S3
-$ dep-cache download 
+$ dep-cache download
 
 # Install dependencies. These would run super fast if the cache exists
 $ bundle install --path .bundle --jobs=4

--- a/config.go
+++ b/config.go
@@ -13,11 +13,17 @@ var (
 	reEnvVar = regexp.MustCompile(`(?i)\$([\w\d\_]+)`)
 )
 
+const (
+	downloadPolicyDefault      = "default"
+	downloadPolicySkipNotEmpty = "skip_not_empty"
+)
+
 type Cache struct {
-	Manifest string `json:"manifest"`
-	Path     string `json:"path"`
-	Prefix   string `json:"prefix"`
-	Key      string `json:"-"`
+	Manifest       string `json:"manifest"`
+	Path           string `json:"path"`
+	Prefix         string `json:"prefix"`
+	DownloadPolicy string `json:"download_policy"`
+	Key            string `json:"-"`
 }
 
 type Config struct {
@@ -65,6 +71,19 @@ func readConfig(path string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func (c *Cache) validate() error {
+	if c.DownloadPolicy == "" {
+		c.DownloadPolicy = downloadPolicyDefault
+	}
+
+	switch c.DownloadPolicy {
+	case downloadPolicyDefault, downloadPolicySkipNotEmpty:
+		return nil
+	default:
+		return fmt.Errorf("invalid download policy: %v", c.DownloadPolicy)
+	}
 }
 
 func (c *Cache) prepare() error {


### PR DESCRIPTION
Adds a new `download_policy` to cache manifest to allow skips in case of cache directory already existing and not empty.