### PR TITLE
Make S3 endpoint configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,10 +28,12 @@ type Cache struct {
 
 type Config struct {
 	S3 struct {
-		Key    string `json:"key"`
-		Secret string `json:"secret"`
-		Region string `json:"region"`
-		Bucket string `json:"bucket"`
+		Key            string `json:"key"`
+		Secret         string `json:"secret"`
+		Region         string `json:"region"`
+		Bucket         string `json:"bucket"`
+		Endpoint       string `json:"endpoint"`
+		ForcePathStyle bool   `json:"force_path_style"`
 	} `json:"s3"`
 	Caches []Cache `json:"cache"`
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func setupS3(config *Config) error {
 		return err
 	}
 
+	sess.Config.S3ForcePathStyle = aws.Bool(config.S3.ForcePathStyle)
+
 	if config.S3.Bucket == "" {
 		return errors.New("bucket name is not set")
 	}
@@ -53,6 +55,10 @@ func setupS3(config *Config) error {
 			config.S3.Secret,
 			"",
 		)
+	}
+
+	if config.S3.Endpoint != "" {
+		s3session.Config.Endpoint = aws.String(config.S3.Endpoint)
 	}
 
 	s3session = sess


### PR DESCRIPTION
Adds new configuration options to handle S3 endpoint:

- `endpoint` - For specifying a custom S3 endpoint
- `force_path_style` - To enforce path style for S3 URLs